### PR TITLE
Move audio player import from eventhandler.py to cbevents.py

### DIFF
--- a/handlers/eventhandler.py
+++ b/handlers/eventhandler.py
@@ -27,7 +27,6 @@ class EventHandler:
         vip_refresh_interval=300,
         admin_refresh_interval=300,
         action_refresh_interval=300,
-        audio_device=None,
         aws_key=None,
         aws_secret=None):
         from helpers.cbevents import CBEvents
@@ -81,12 +80,6 @@ class EventHandler:
         self.action_users = None
 
         if 'vip_audio' in self.cb_events.active_components:
-            # if not audio_device:
-            #     logger.error("VIP audio is enabled. Must provide audio device name for output.")
-            #     raise ValueError("audio_device must be provided when VIP audio is enabled.")
-            from chataudio import AudioPlayer
-            ##  TODO: AudioPlayer
-            self.audio_player = AudioPlayer(audio_device)
             self.vip_users = {}
             self.vip_refresh_interval = vip_refresh_interval
             self.load_vip_users()
@@ -167,7 +160,7 @@ class EventHandler:
                     "admin": self.admin_users,
                     "custom_actions": self.action_users
                 }
-                process_result = self.cb_events.process_event(event, privileged_users, self.audio_player)
+                process_result = self.cb_events.process_event(event, privileged_users)
                 logger.debug(f"process_result: {process_result}")
                 self.event_queue.task_done()
             except queue.Empty:

--- a/helpers/cbevents.py
+++ b/helpers/cbevents.py
@@ -6,6 +6,7 @@ import threading
 import time
 
 from utils import MongoJSONEncoder
+from chataudio.audioplayer import AudioPlayer
 
 logger = logging.getLogger('mongobate.helpers.cbevents')
 logger.setLevel(logging.DEBUG)
@@ -40,8 +41,9 @@ class CBEvents:
             self.spray_bottle_url = config.get("General", "spray_bottle_url")
 
         self.actions = Actions(actions_args)
+        self.audio_player = AudioPlayer()
 
-    def process_event(self, event, privileged_users, audio_player):
+    def process_event(self, event, privileged_users):
         try:
             print(json.dumps(event, sort_keys=True, indent=4, cls=MongoJSONEncoder))
 
@@ -67,7 +69,7 @@ class CBEvents:
             elif event_method == "roomSubjectChange":
                 process_result = self.room_subject_change(event_object)
             elif event_method == "userEnter":
-                process_result = self.user_enter(event_object, vip_users, audio_player)
+                process_result = self.user_enter(event_object, vip_users)
             elif event_method == "userLeave":
                 process_result = self.user_leave(event_object)
             elif event_method == "follow":
@@ -77,7 +79,7 @@ class CBEvents:
             elif event_method == "mediaPurchase":
                 process_result = self.media_purchase(event_object)
             elif event_method == "chatMessage":
-                process_result = self.chat_message(event_object, admin_users, action_users, audio_player)
+                process_result = self.chat_message(event_object, admin_users, action_users)
             else:
                 logger.warning(f"Unknown event method: {event_method}")
                 process_result = False
@@ -264,7 +266,7 @@ class CBEvents:
             logger.exception("Error processing room subject change event", exc_info=e)
             return False
     
-    def user_enter(self, event, vip_users, audio_player):
+    def user_enter(self, event, vip_users):
         """
         {
             "broadcaster": "testuser",
@@ -294,7 +296,7 @@ class CBEvents:
                         audio_file_path = f"{self.vip_audio_directory}/{audio_file}"
                         logger.debug(f"audio_file_path: {audio_file_path}")
                         logger.info(f"Playing VIP audio for user: {username}")
-                        audio_player.play_audio(audio_file_path)
+                        self.audio_player.play_audio(audio_file_path)
                         logger.info(f"VIP audio played for user: {username}. Resetting cooldown.")
                         self.vip_cooldown[username] = current_time
             return True
@@ -396,7 +398,7 @@ class CBEvents:
             logger.exception("Error processing media purchase event", exc_info=e)
             return False
 
-    def chat_message(self, event, admin_users, action_users, audio_player):
+    def chat_message(self, event, admin_users, action_users):
         """
         {
             "message": {
@@ -442,9 +444,8 @@ class CBEvents:
                             audio_file_path = f"{self.vip_audio_directory}/{audio_file}"
                             logger.debug(f"audio_file_path: {audio_file_path}")
                             logger.info(f"Playing custom action audio for user: {username}")
-                            audio_player.play_audio(audio_file_path)
+                            self.audio_player.play_audio(audio_file_path)
             return True
         except Exception as e:
             logger.exception("Error processing chat message event", exc_info=e)
             return False
-    


### PR DESCRIPTION
Move `AudioPlayer` import and usage from `eventhandler.py` to `cbevents.py`.

* **helpers/cbevents.py**
  - Import `AudioPlayer` from `chataudio.audioplayer`.
  - Initialize `AudioPlayer` in the `__init__` method of `CBEvents` class.
  - Update `process_event` method to remove `audio_player` parameter.
  - Update `user_enter` and `chat_message` methods to use `self.audio_player` instead of `audio_player` parameter.

* **handlers/eventhandler.py**
  - Remove import of `AudioPlayer` from `chataudio`.
  - Remove initialization of `AudioPlayer` in `__init__` method of `EventHandler` class.
  - Update `process_event` method call to pass `self.cb_events.audio_player` instead of `self.audio_player`.
  - Remove `audio_device` parameter from `__init__` method of `EventHandler` class.
  - Remove `audio_player` parameter from `process_event` method call.

