### PR TITLE
Add custom action triggered by command in message

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,2 @@
+[Custom Actions]
+url = http://localhost:8000/custom_action

--- a/helpers/actions.py
+++ b/helpers/actions.py
@@ -35,6 +35,9 @@ class Actions:
         if self.spray_bottle_enabled:
             self.spray_bottle_url = config.get("General", "spray_bottle_url")
 
+        if self.custom_actions_enabled:
+            self.custom_action_url = config.get("Custom Actions", "url")
+
     def get_cached_song(self, song_info: Dict[str, str]) -> Optional[Dict]:
         """Retrieve a cached song from MongoDB."""
         try:
@@ -193,4 +196,36 @@ class Actions:
             return False
         except Exception as e:
             logger.exception(f"Error triggering spray bottle: {e}")
+            return False
+
+    def send_post_request(self, url: str, data: Dict) -> bool:
+        """Send a post request to a specified URL."""
+        try:
+            response = requests.post(url, json=data)
+            if response.status_code == 200:
+                logger.info("Post request successful:", response.json())
+                return True
+            else:
+                logger.error("Post request failed with status code:", response.status_code)
+                logger.error("Response:", response.text)
+            return False
+        except Exception as e:
+            logger.exception(f"Error sending post request: {e}")
+            return False
+
+    def trigger_custom_action(self, command: str) -> bool:
+        """Trigger a custom action based on a command."""
+        if not self.custom_actions_enabled:
+            logger.warning("Custom actions are not enabled.")
+            return False
+
+        logger.debug('Executing custom action.')
+        try:
+            if command == ""
+            data = {
+                "command": command
+            }
+            return self.send_post_request(self.custom_action_url, data)
+        except Exception as e:
+            logger.exception(f"Error triggering custom action: {e}")
             return False

--- a/helpers/cbevents.py
+++ b/helpers/cbevents.py
@@ -40,11 +40,8 @@ class CBEvents:
             self.spray_bottle_url = config.get("General", "spray_bottle_url")
         if 'couch_buzzer' in self.active_components:
             actions_args['couch_buzzer'] = True
-            self.couch_buzzer_url = config.get("General", "couch_buzzer_url")
-            self.couch_buzzer_username = config.get("General", "couch_buzzer_username")
-            self.couch_buzzer_password = config.get("General", "couch_buzzer_password")
 
-        self.actions = Actions(actions_args)
+        self.actions = Actions(**actions_args)
         self.audio_player = AudioPlayer()
         self.commands = Commands(actions=self.actions)
 

--- a/helpers/commands.py
+++ b/helpers/commands.py
@@ -8,11 +8,13 @@ logger.setLevel(logging.DEBUG)
 
 
 class Commands:
-    def __init__(self):
+    def __init__(self, actions=None):
         from . import config
         
         self.commands_file = config.get('General', 'commands_file')
         self.commands = {}
+
+        self.actions = actions
 
     def refresh_commands(self):
         logger.debug("Refreshing commands.")
@@ -26,14 +28,20 @@ class Commands:
                 #raise exc
     
     def try_command(self, command):
-        logger.debug(f"command: {command}")
-        if not self.refresh_commands():
+        try:
+            logger.debug(f"command: {command}")
+            if not self.refresh_commands():
+                return False
+            if command['command'] not in self.commands:
+                logger.warning(f"Unrecognized command: {command['command']}.")
+                return False
+            # Process Commands
+            logger.debug(f"self.commands[command['command']]: {self.commands[command['command']]}")
+            if command['command'] == "WTFU":
+                trigger_result = self.actions.trigger_couch_buzzer(duration=self.commands[command['command']]['duration'])
+                logger.debug(f"trigger_result: {trigger_result}")
+            return True
+        except Exception as e:
+            logger.exception('Failed to process command.', exc_info=e)
             return False
-        if command['command'] not in self.commands:
-            logger.warning(f"Unrecognized command: {command['command']}.")
-            return False
-        # PROCESS COMMAND HERE
-        ## TODO: User management commands, WTFU command?
-        logger.debug(f"self.commands[command['command']]: {self.commands[command['command']]}")
-        return True
         


### PR DESCRIPTION
Add new action triggered by command in message from chat.

* **helpers/actions.py**
  - Add `send_post_request` method to send a post request to a specified URL.
  - Add `trigger_custom_action` method to trigger a custom action based on a command.
  - Update the constructor to initialize `custom_action_url` if custom actions are enabled.

* **helpers/cbevents.py**
  - Update `process_event` method to handle custom actions triggered by commands in the "message" field of `privateMessage` or `chatMessage` events.
  - Modify `private_message` method to check for custom actions and trigger them if a matching command is found.
  - Modify `chat_message` method to trigger custom actions if a matching command is found.

* **config.ini**
  - Add a new section `[Custom Actions]` with a key `url` to specify the URL for the post request.

