### PR TITLE
Add airhorns sound on fanclub join

### DIFF
--- a/helpers/cbevents.py
+++ b/helpers/cbevents.py
@@ -41,6 +41,9 @@ class CBEvents:
             actions_args['couch_buzzer'] = True
         if 'obs_integration' in self.active_components:
             actions_args['obs_integration'] = True
+        if 'event_audio' in self.active_components:
+            actions_args['event_audio'] = True
+            self.fanclub_join_audio_path = config.get("EventAudio", "fanclub_join")
 
         self.actions = Actions(**actions_args)
         self.audio_player = AudioPlayer()
@@ -231,6 +234,8 @@ class CBEvents:
         try:
             # Process fanclub join event
             logger.info("Fanclub join event received.")
+            if 'event_audio' in self.active_components:
+                self.audio_player.play_audio(self.fanclub_join_audio_path)
             return True
         except Exception as e:
             logger.exception("Error processing fanclub join event", exc_info=e)


### PR DESCRIPTION
Related to #23

Add functionality to play airhorns sound on fanclub join.

* Add a check for "event_audio" in `self.active_components` in the `__init__` method.
* Load the path to the fanclub join audio from the config file in the `__init__` method.
* Add a call to `self.audio_player.play_audio` in the `fanclub_join` method to play the airhorns sound file.
* Check for "event_audio" in `self.active_components` in the `fanclub_join` method and play audio if true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rndmzd/mongobate/pull/39?shareId=ab6cffe4-9486-4b79-aaa2-ab704afe544a).