### PR TITLE
Fix audio file assignment in CBEvents class to correctly reference ac…

### DIFF
--- a/helpers/cbevents.py
+++ b/helpers/cbevents.py
@@ -480,7 +480,7 @@ class CBEvents:
                     for action_message in action_messages.keys():
                         if action_message in message:
                             logger.info(f"Message matches action message for user {username}. Executing action.")
-                            audio_file = action_messages[message]
+                            audio_file = action_messages[action_message]
                             logger.debug(f"audio_file: {audio_file}")
                             audio_file_path = f"{self.vip_audio_directory}/{audio_file}"
                             logger.debug(f"audio_file_path: {audio_file_path}")


### PR DESCRIPTION

This pull request includes a fix to the `chat_message` method in the `helpers/cbevents.py` file to correct the retrieval of the `audio_file` from the `action_messages` dictionary.

Bug fix:

* [`helpers/cbevents.py`](diffhunk://#diff-25c5342e1ea9ba545c01a23e1dfe9bcee4aeba87efe4603c1e225a5b8730dc62L483-R483): Corrected the key used to retrieve the `audio_file` from `action_messages` to ensure the correct audio file is executed when a message matches an action message.