### PR TITLE
Add song requester overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ commands.yaml
 chatdj/server/
 .env
 **_wordcloud.png
+**/repomix*
+.repomixignore

--- a/handlers/obshandler.py
+++ b/handlers/obshandler.py
@@ -278,8 +278,8 @@ class OBSHandler:
         Returns:
             True if successful, False otherwise
         """
-        logger.debug("Setting song requester text...")
         # First set the text
+        logger.debug("Setting song requester text...")
         await self.send_request('SetInputSettings', {
             'inputName': 'SongRequester',
             'inputSettings': {
@@ -291,6 +291,7 @@ class OBSHandler:
         logger.debug("Making song requester source visible...")
         visibility_result = await self.set_source_visibility('main', 'SongRequester', True)
         logger.debug(f"Source visibility result: {visibility_result}")
+
         return visibility_result
 
     async def hide_song_requester(self) -> bool:
@@ -299,19 +300,22 @@ class OBSHandler:
         Returns:
             True if successful, False otherwise
         """
+        # First hide the source
+        logger.debug("Hiding song requester source...")
+        visibility_result = await self.set_source_visibility('main', 'SongRequester', False)
+        logger.debug(f"Source visibility result: {visibility_result}")
+
+        await asyncio.sleep(1)
+
+        # Then clear the text
         logger.debug("Clearing song requester text...")
-        # First clear the text
         await self.send_request('SetInputSettings', {
             'inputName': 'SongRequester',
             'inputSettings': {
                 'text': ''
             }
         })
-            
-        # Then hide the source
-        logger.debug("Hiding song requester source...")
-        visibility_result = await self.set_source_visibility('main', 'SongRequester', False)
-        logger.debug(f"Source visibility result: {visibility_result}")
+        
         return visibility_result
 
     async def trigger_song_requester_overlay(self, requester_name: str, song_details: str, display_duration: int = 10) -> None:

--- a/handlers/obshandler.py
+++ b/handlers/obshandler.py
@@ -221,6 +221,46 @@ class OBSHandler:
             return response.get('sceneItemEnabled')
         return None
 
+    async def show_song_requester(self, requester_name: str, song_details: str) -> bool:
+        """Show the song requester name and song details on the overlay.
+        
+        Args:
+            requester_name: Name of the user who requested the song
+            song_details: Details of the requested song (artist and name)
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        response = await self.send_request('SetTextGDIPlusProperties', {
+            'source': 'SongRequester',
+            'text': f'Requested by: {requester_name}\nSong: {song_details}'
+        })
+        return response is not None
+
+    async def hide_song_requester(self) -> bool:
+        """Hide the song requester name and song details from the overlay.
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        response = await self.send_request('SetTextGDIPlusProperties', {
+            'source': 'SongRequester',
+            'text': ''
+        })
+        return response is not None
+
+    async def trigger_song_requester_overlay(self, requester_name: str, song_details: str, display_duration: int = 10) -> None:
+        """Trigger the song requester overlay to show and then hide after a duration.
+        
+        Args:
+            requester_name: Name of the user who requested the song
+            song_details: Details of the requested song (artist and name)
+            display_duration: Duration to display the requester name and song details (in seconds)
+        """
+        if await self.show_song_requester(requester_name, song_details):
+            await asyncio.sleep(display_duration)
+            await self.hide_song_requester()
+
     def run_sync(self, coro):
         """Run a coroutine synchronously.
         
@@ -254,4 +294,8 @@ class OBSHandler:
 
     def get_source_visibility_sync(self, scene_key: str, source_name: str) -> Optional[bool]:
         """Synchronous version of get_source_visibility()."""
-        return self.run_sync(self.get_source_visibility(scene_key, source_name)) 
+        return self.run_sync(self.get_source_visibility(scene_key, source_name))
+
+    def trigger_song_requester_overlay_sync(self, requester_name: str, song_details: str, display_duration: int = 10) -> None:
+        """Synchronous version of trigger_song_requester_overlay()."""
+        self.run_sync(self.trigger_song_requester_overlay(requester_name, song_details, display_duration))

--- a/helpers/cbevents.py
+++ b/helpers/cbevents.py
@@ -144,7 +144,8 @@ class CBEvents:
                             if not self.actions.available_in_market(song_uri):
                                 logger.warning(f"Song not available in user market: {song_info}")
                                 continue
-                            add_queue_result = self.actions.add_song_to_queue(song_uri)
+                            song_details = f"{song_info['artist']} - {song_info['song']}"
+                            add_queue_result = self.actions.add_song_to_queue(song_uri, event["user"]["username"], song_details)
                             logger.debug(f'add_queue_result: {add_queue_result}')
                             if not add_queue_result:
                                 logger.error(f"Failed to add song to queue: {song_info}")


### PR DESCRIPTION
Fixes #43

Add functionality to display song requester and song details on OBS overlay.

* Add `show_song_requester`, `hide_song_requester`, and `trigger_song_requester_overlay` methods in `handlers/obshandler.py` to manage the display of requester name and song details.
* Update `add_song_to_queue` method in `helpers/actions.py` to trigger the song requester overlay with requester name and song details.
* Add `trigger_song_requester_overlay` method in `helpers/actions.py` to call the corresponding method in `OBSHandler`.
* Update `tip` method in `helpers/cbevents.py` to pass the requester name and song details to the `add_song_to_queue` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rndmzd/mongobate/pull/51?shareId=2233dcae-c533-408b-ba76-a6c1a1d72531).