### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/handlers/eventhandler.py
+++ b/handlers/eventhandler.py
@@ -52,7 +52,8 @@ class EventHandler:
 
         try:
             if self.mongo_connection_uri:
-                logger.debug(f"Connecting with URI: {self.mongo_connection_uri}")
+                sanitized_uri = self.mongo_connection_uri.replace(aws_secret_pe, "****")
+                logger.debug(f"Connecting with URI: {sanitized_uri}")
                 self.mongo_client = MongoClient(self.mongo_connection_uri)
             else:
                 self.mongo_client = MongoClient(


### PR DESCRIPTION
Potential fix for [https://github.com/rndmzd/mongobate/security/code-scanning/2](https://github.com/rndmzd/mongobate/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information such as `aws_secret` is not logged in clear text. Instead of logging the full connection URI, we can log a sanitized version that omits the sensitive parts. This way, we can still have useful logging information without exposing sensitive data.

- Replace the line that logs the connection URI with a sanitized version that omits the `aws_secret`.
- Specifically, modify line 55 in `handlers/eventhandler.py` to log a sanitized version of the URI.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
