### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/handlers/dbhandler.py
+++ b/handlers/dbhandler.py
@@ -59,10 +59,19 @@ class DBHandler:
                 f"?authMechanism=MONGODB-AWS&authSource=$external"
             )
 
+    def _sanitize_uri(self, uri):
+        # Remove sensitive information from the URI
+        parts = uri.split('@')
+        if len(parts) == 2:
+            sanitized_uri = parts[1]  # Keep only the part after '@'
+            return f"mongodb://<credentials>@{sanitized_uri}"
+        return uri
+
     def connect_to_mongodb(self):
         try:
             if self.mongo_connection_uri:
-                logger.debug(f"Connecting with URI: {self.mongo_connection_uri}")
+                sanitized_uri = self._sanitize_uri(self.mongo_connection_uri)
+                logger.debug(f"Connecting with URI: {sanitized_uri}")
                 self.mongo_client = MongoClient(self.mongo_connection_uri)
             else:
                 self.mongo_client = MongoClient(


### PR DESCRIPTION
Potential fix for [https://github.com/rndmzd/mongobate/security/code-scanning/1](https://github.com/rndmzd/mongobate/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as `aws_key` and `aws_secret` is not logged. Instead of logging the full `mongo_connection_uri`, we can log a sanitized version that omits the sensitive parts. This way, we retain useful logging information without exposing sensitive data.

- Modify the logging statement on line 65 in `handlers/dbhandler.py` to log a sanitized version of the URI.
- Introduce a helper function to sanitize the URI by removing sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
