### PR TITLE
Fix clear-text logging of sensitive information

### DIFF
--- a/handlers/dbhandler.py
+++ b/handlers/dbhandler.py
@@ -54,7 +54,7 @@ class DBHandler:
 
             # Construct the URI with proper escaping and formatting
             self.mongo_connection_uri = (
-                f"mongodb://{aws_key_pe}:{aws_secret_pe}@"
+                f"mongodb://{aws_key_pe}:****@"
                 f"[{mongo_host_pe}]:{mongo_port_pe}/"
                 f"?authMechanism=MONGODB-AWS&authSource=$external"
             )

--- a/handlers/eventhandler.py
+++ b/handlers/eventhandler.py
@@ -45,7 +45,7 @@ class EventHandler:
 
             # Construct the URI with proper escaping and formatting
             self.mongo_connection_uri = (
-                f"mongodb://{aws_key_pe}:{aws_secret_pe}@"
+                f"mongodb://{aws_key_pe}:****@"
                 f"[{mongo_host_pe}]:{mongo_port_pe}/"
                 f"?authMechanism=MONGODB-AWS&authSource=$external"
             )

--- a/helpers/actions.py
+++ b/helpers/actions.py
@@ -239,7 +239,7 @@ class Actions(HTTPRequestHandler):
     
     def trigger_couch_buzzer(self, duration=1) -> bool:
         """Trigger the couch buzzer action."""
-        credentials = f"{self.couch_buzzer_username}:{self.couch_buzzer_password}"
+        credentials = f"{self.couch_buzzer_username}:****"
         encoded_credentials = base64.b64encode(credentials.encode('utf-8')).decode('utf-8')
         return self.make_request(
             self.couch_buzzer_url,

--- a/utils/db.py
+++ b/utils/db.py
@@ -29,7 +29,7 @@ class DatabaseManager:
         host = urllib.parse.quote_plus(config.get('MongoDB', 'host'))
         port = urllib.parse.quote_plus(config.get('MongoDB', 'port'))
         
-        uri = f"mongodb://{aws_key}:{aws_secret}@[{host}]:{port}/?authMechanism=MONGODB-AWS&authSource=$external"
+        uri = f"mongodb://{aws_key}:****@[{host}]:{port}/?authMechanism=MONGODB-AWS&authSource=$external"
         return MongoClient(uri)
         
     def _get_standard_connection(self, config):


### PR DESCRIPTION
Fixes #62

Fix clear-text logging of sensitive information in multiple files.

* **handlers/dbhandler.py**: Mask `aws_secret_pe` in the MongoDB connection URI.
* **handlers/eventhandler.py**: Mask `aws_secret_pe` in the MongoDB connection URI.
* **helpers/actions.py**: Mask `couch_buzzer_password` in the credentials string.
* **utils/db.py**: Mask `aws_secret` in the MongoDB connection URI and add a newline at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rndmzd/mongobate/pull/63?shareId=03d8996f-aea6-4452-be28-708a9031a4cf).